### PR TITLE
Update contracts.py

### DIFF
--- a/bscscan/modules/contracts.py
+++ b/bscscan/modules/contracts.py
@@ -21,7 +21,7 @@ class Contracts:
             async with BscScan(YOUR_API_KEY) as client:
                 print(
                     await client.get_contract_abi(
-                        address="0x0000000000000000000000000000000000001004"
+                        contract_address="0x0000000000000000000000000000000000001004"
                     )
                 )
 
@@ -55,7 +55,7 @@ class Contracts:
             async with BscScan(YOUR_API_KEY) as client:
                 print(
                     await client.get_contract_source_code(
-                        address="0x0000000000000000000000000000000000001004"
+                        contract_address="0x0000000000000000000000000000000000001004"
                     )
                 )
 


### PR DESCRIPTION
Use 'contract_address'  in example instead of 'address' as address caused the example code to throw the error "get_contract_source_code() got an unexpected keyword argument 'address'", Tested on Python 3.9.5