### PR TITLE
Specify minimum Python version to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "bscscan.modules",
         "bscscan.utils",
     ],
+    python_requires='>=3.7',
     install_requires=["aiohttp", "requests"],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
According to the Python documentation https://docs.python.org/3/library/importlib.html#module-importlib.resources, importlib.resources used in module bscan.core.base was introduced in version 3.7.