### PR TITLE
Added support for BSC testnet

### DIFF
--- a/bscscan/client.py
+++ b/bscscan/client.py
@@ -6,7 +6,7 @@ from bscscan.core.sync_client import SyncClient
 class BscScan:
     """Client factory."""
 
-    def __new__(cls, api_key: str, asynchronous=True, debug=False) -> BaseClient:
+    def __new__(cls, api_key: str, asynchronous=True, testnet=False, debug=False) -> BaseClient:
         """Create a new client.
 
         Args:
@@ -18,5 +18,5 @@ class BscScan:
             BaseClient: BscScan client.
         """
         if asynchronous:
-            return AsyncClient(api_key=api_key, debug=debug)
-        return SyncClient(api_key=api_key, debug=debug)
+            return AsyncClient(api_key=api_key, testnet=testnet, debug=debug)
+        return SyncClient(api_key=api_key, testnet=testnet, debug=debug)

--- a/bscscan/client.py
+++ b/bscscan/client.py
@@ -6,7 +6,8 @@ from bscscan.core.sync_client import SyncClient
 class BscScan:
     """Client factory."""
 
-    def __new__(cls, api_key: str, asynchronous=True, testnet=False, debug=False) -> BaseClient:
+    def __new__(cls, api_key: str, asynchronous=True,
+                testnet=False, debug=False) -> BaseClient:
         """Create a new client.
 
         Args:

--- a/bscscan/core/async_client.py
+++ b/bscscan/core/async_client.py
@@ -11,13 +11,17 @@ class AsyncClient(BaseClient):
             if not func.startswith("_"):  # disabled if _
                 attr = getattr(getattr(bscscan, v["module"]), func)
                 setattr(self, func, await self._exec(attr))
-        self._server_prefix = fields.PREFIX if not self._isTestnet else fields.TESTNET_PREFIX
         return self
 
     async def _exec(self, func):
+        if self._isTestnet:
+            server_prefix = fields.TESTNET_PREFIX
+        else:
+            server_prefix = fields.PREFIX
+
         async def wrapper(*args, **kwargs):
             url = (
-                f"{self._server_prefix}"
+                f"{server_prefix}"
                 f"{func(*args, **kwargs)}"
                 f"{fields.API_KEY}"
                 f"{self._api_key}"

--- a/bscscan/core/async_client.py
+++ b/bscscan/core/async_client.py
@@ -11,12 +11,13 @@ class AsyncClient(BaseClient):
             if not func.startswith("_"):  # disabled if _
                 attr = getattr(getattr(bscscan, v["module"]), func)
                 setattr(self, func, await self._exec(attr))
+        self._server_prefix = fields.PREFIX if not self._isTestnet else fields.TESTNET_PREFIX
         return self
 
     async def _exec(self, func):
         async def wrapper(*args, **kwargs):
             url = (
-                f"{fields.PREFIX}"
+                f"{self._server_prefix}"
                 f"{func(*args, **kwargs)}"
                 f"{fields.API_KEY}"
                 f"{self._api_key}"

--- a/bscscan/core/base.py
+++ b/bscscan/core/base.py
@@ -10,10 +10,12 @@ class BaseClient:
     def __init__(
         self,
         api_key: str,
-        debug: bool = False,  # display generated URLs for debugging purposes
+        testnet: bool = False,  # connect to testnet instead of mainnet
+        debug: bool = False,   # display generated URLs for debugging purposes
     ):
         self._config = self._load_config()
         self._api_key = api_key
+        self._isTestnet = testnet
         self._debug = debug
 
     @staticmethod

--- a/bscscan/core/sync_client.py
+++ b/bscscan/core/sync_client.py
@@ -11,13 +11,17 @@ class SyncClient(BaseClient):
             if not func.startswith("_"):  # disabled if _
                 attr = getattr(getattr(bscscan, v["module"]), func)
                 setattr(self, func, self._exec(attr))
-        self._server_prefix = fields.PREFIX if not self._isTestnet else fields.TESTNET_PREFIX
         return self
 
     def _exec(self, func):
+        if self._isTestnet:
+            server_prefix = fields.TESTNET_PREFIX
+        else:
+            server_prefix = fields.PREFIX
+
         def wrapper(*args, **kwargs):
             url = (
-                f"{self._server_prefix}"
+                f"{server_prefix}"
                 f"{func(*args, **kwargs)}"
                 f"{fields.API_KEY}"
                 f"{self._api_key}"

--- a/bscscan/core/sync_client.py
+++ b/bscscan/core/sync_client.py
@@ -11,12 +11,13 @@ class SyncClient(BaseClient):
             if not func.startswith("_"):  # disabled if _
                 attr = getattr(getattr(bscscan, v["module"]), func)
                 setattr(self, func, self._exec(attr))
+        self._server_prefix = fields.PREFIX if not self._isTestnet else fields.TESTNET_PREFIX
         return self
 
     def _exec(self, func):
         def wrapper(*args, **kwargs):
             url = (
-                f"{fields.PREFIX}"
+                f"{self._server_prefix}"
                 f"{func(*args, **kwargs)}"
                 f"{fields.API_KEY}"
                 f"{self._api_key}"

--- a/bscscan/enums/fields_enum.py
+++ b/bscscan/enums/fields_enum.py
@@ -27,6 +27,7 @@ class FieldsEnum:
     PAGE: str = "&page="
     POSITION: str = "&position="
     PREFIX: str = "https://api.bscscan.com/api?"
+    TESTNET_PREFIX: str = "https://api-testnet.bscscan.com/api?"
     SORT: str = "&sort="
     START_BLOCK: str = "&startblock="
     START_DATE: str = "&startdate="

--- a/test/test_bscscan_async.py
+++ b/test/test_bscscan_async.py
@@ -26,12 +26,13 @@ class Case(IsolatedAsyncioTestCase):
     async def test_methods(self):
         print(f"\nMODULE: {self._MODULE}")
         config = load(CONFIG_PATH)
-        async with BscScan(api_key=API_KEY, asynchronous=True, debug=True) as bscscan:
+        async with BscScan(api_key=API_KEY, asynchronous=True, testnet=False, debug=True) as bscscan:
             for fun, v in config.items():
                 if not fun.startswith("_"):  # disabled if _
                     if v["module"] == self._MODULE:
                         res = await getattr(bscscan, fun)(**v["kwargs"])
-                        print(f"ASYNC: True, METHOD: {fun}, RTYPE: {type(res)}")
+                        print(
+                            f"ASYNC: True, METHOD: {fun}, RTYPE: {type(res)}")
                         fname = f"logs/standard/{fun}.json"
                         log = {
                             "method": fun,

--- a/test/test_bscscan_sync.py
+++ b/test/test_bscscan_sync.py
@@ -26,12 +26,13 @@ class Case(TestCase):
     def test_methods(self):
         print(f"\nMODULE: {self._MODULE}")
         config = load(CONFIG_PATH)
-        with BscScan(api_key=API_KEY, asynchronous=False, debug=True) as bscscan:
+        with BscScan(api_key=API_KEY, asynchronous=False, testnet=False, debug=True) as bscscan:
             for fun, v in config.items():
                 if not fun.startswith("_"):  # disabled if _
                     if v["module"] == self._MODULE:
                         res = getattr(bscscan, fun)(**v["kwargs"])
-                        print(f"ASYNC: False, METHOD: {fun}, RTYPE: {type(res)}")
+                        print(
+                            f"ASYNC: False, METHOD: {fun}, RTYPE: {type(res)}")
                         fname = f"logs/standard/{fun}.json"
                         log = {
                             "method": fun,


### PR DESCRIPTION
Hi,

I've added support to your library for accessing BSC testnet API. I've tried to run the automated tests there, but they seem to fail (not sure exactly why). However for my needs it works fine in the testnet (I can do some queries and everything seems fine). I thought you could include it as experimental feature if you find it useful.

Let me know if anything.

Cheers,
Roberto